### PR TITLE
Serial port fixes.

### DIFF
--- a/sa818.py
+++ b/sa818.py
@@ -48,7 +48,7 @@ class SA818:
   TAIL = "AT+SETTAIL"
   NARROW = 0
   WIDE = 1
-  PORTS = ('/dev/ttyAMA0', '/dev/ttyUSB0')
+  PORTS = ('/dev/serial0', '/dev/ttyUSB0')
   READ_TIMEOUT = 1.0
 
   def __init__(self, port=None):
@@ -67,7 +67,6 @@ class SA818:
         break
       except serial.SerialException as err:
         logger.debug(err)
-        raise IOError(err) from err
 
     if not isinstance(self.serial, serial.Serial):
       raise IOError('Error openning the serial port')


### PR DESCRIPTION
Changes default Pi serial port to /dev/serial0.  ttyAMA0 is the Blueooth UART on a
a Pi with WLAN/BT.   serial0 is the UART on pins GPIO14/GPIO15 on all Pi's under
standard configurations.

Tries all the ports in the default list.